### PR TITLE
Error Fix

### DIFF
--- a/addons/sourcemod/scripting/include/tf2wearables.inc
+++ b/addons/sourcemod/scripting/include/tf2wearables.inc
@@ -169,14 +169,18 @@ stock void TF2_RemoveWeapon(int client, int weaponIndex) {
 	
 	// bug #6206
 	// papering over a valve bug where a weapon's extra wearables aren't properly removed from the weapon's owner
-	int extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
-	if (extraWearable != -1) {
-		TF2_RemoveWearable(client, extraWearable);
+	if(HasEntProp(weaponIndex, Prop_Send, "m_hExtraWearable")) {
+		int extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
+		if (extraWearable != -1) {
+			TF2_RemoveWearable(client, extraWearable);
+		}
 	}
 
-	extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
-	if (extraWearable != -1) {
-		TF2_RemoveWearable(client, extraWearable);
+	if(HasEntProp(weaponIndex, Prop_Send, "m_hExtraWearableViewModel")) {
+		extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
+		if (extraWearable != -1) {
+			TF2_RemoveWearable(client, extraWearable);
+		}
 	}
 	
 	RemovePlayerItem(client, weaponIndex);

--- a/addons/sourcemod/scripting/include/tf2wearables.inc
+++ b/addons/sourcemod/scripting/include/tf2wearables.inc
@@ -167,10 +167,12 @@ stock void TF2_RemoveWeapon(int client, int weaponIndex) {
 		return;
 	}
 	
+	int extraWearable;
+	
 	// bug #6206
 	// papering over a valve bug where a weapon's extra wearables aren't properly removed from the weapon's owner
 	if(HasEntProp(weaponIndex, Prop_Send, "m_hExtraWearable")) {
-		int extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
+		extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
 		if (extraWearable != -1) {
 			TF2_RemoveWearable(client, extraWearable);
 		}

--- a/addons/sourcemod/scripting/include/tf2wearables.inc
+++ b/addons/sourcemod/scripting/include/tf2wearables.inc
@@ -167,7 +167,7 @@ stock void TF2_RemoveWeapon(int client, int weaponIndex) {
 		return;
 	}
 	
-	if(TF2_IsWearable(weaponIndex)) {
+	if (TF2_IsWearable(weaponIndex)) {
 		ThrowError("This function is intended to be used with weapons only.");
 	}
 	

--- a/addons/sourcemod/scripting/include/tf2wearables.inc
+++ b/addons/sourcemod/scripting/include/tf2wearables.inc
@@ -167,22 +167,20 @@ stock void TF2_RemoveWeapon(int client, int weaponIndex) {
 		return;
 	}
 	
-	int extraWearable;
+	if(TF2_IsWearable(weaponIndex)) {
+		ThrowError("This function is intended to be used with weapons only.");
+	}
 	
 	// bug #6206
 	// papering over a valve bug where a weapon's extra wearables aren't properly removed from the weapon's owner
-	if(HasEntProp(weaponIndex, Prop_Send, "m_hExtraWearable")) {
-		extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
-		if (extraWearable != -1) {
-			TF2_RemoveWearable(client, extraWearable);
-		}
+	int extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
+	if (extraWearable != -1) {
+		TF2_RemoveWearable(client, extraWearable);
 	}
 
-	if(HasEntProp(weaponIndex, Prop_Send, "m_hExtraWearableViewModel")) {
-		extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
-		if (extraWearable != -1) {
-			TF2_RemoveWearable(client, extraWearable);
-		}
+	extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
+	if (extraWearable != -1) {
+		TF2_RemoveWearable(client, extraWearable);
 	}
 	
 	RemovePlayerItem(client, weaponIndex);


### PR DESCRIPTION
Fix for "Exception reported: Property "m_hExtraWearable" not found (entity 190/tf_wearable)" error. It happens when the function *TF2_RemoveWeapon(int client, int weaponIndex)* is called on a wearable item (example: Cozy Camper).

The fix add a *HasEntProp* before calling *GetEntPropEnt*. A possible scenario for this error to happen is on a loop to remove weapons. Example:

```
void RemoveAllWeapons(int client)
{
	int weapon;
	for(int i = 0; i <= view_as<int>(TF2LoadoutSlot_PDA2); i++)
	{
		weapon = TF2_GetPlayerLoadoutSlot(client, i, true);
		if(weapon != -1) {
			TF2_RemoveWeapon(client, weapon);
			RemoveEntity(weapon);
		}
	}
}
```